### PR TITLE
Fixed typo in the math of the PSI README

### DIFF
--- a/psi/README.md
+++ b/psi/README.md
@@ -20,7 +20,7 @@ The protocol works as follows:
 4. The client sends `q` to the server.
 5. The server masks `q` and all of its hashed passwords using its mask, i.e. server computes `r = q * ks` and `p_i = hash(password_i) * ks` for each password.
 6. The server sends all these to the client.
-7. The client unmasks its query by taking out `kc` from it, e.g. `r / ks = hash(password) * kc * ks / kc = hash(password) * ks`.
+7. The client unmasks its query by taking out `kc` from it, e.g. `r / kc = hash(password) * kc * ks / kc = hash(password) * ks`.
 8. Note that the client also receives all `p_i = hash(password_i) * ks` from the server, so if the password is in the bad list, one of these will match the unmasked query!
 
 The protocol works because any adversary cannot distinguish (within reasonable time) between `q = h * kc` and `q' = <random>`. In other words, multiplying by an unknown random mask produces uniformly random outputs to adversaries with realistic computational power.


### PR DESCRIPTION
Unless I am mistaken, the client has to divide by his own key as he does not know the server's one.